### PR TITLE
feat: Improve docs and v2 validation coverage

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -6,8 +6,11 @@ on:
       - master
     paths:
       - docs/**
+      - CHANGELOG.md
       - Gemfile
       - Gemfile.lock
+      - package.json
+      - scripts/generate-docs-changelog.mjs
       - .github/workflows/pages.yaml
   workflow_dispatch:
 
@@ -38,6 +41,9 @@ jobs:
         uses: actions/configure-pages@v5
         with:
           enablement: true
+
+      - name: Generate docs changelog
+        run: npm run docs:prepare
 
       - name: Build docs
         run: bundle exec jekyll build --source docs --destination _site

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ npm-debug.log
 # GitHub Pages
 /.cache
 /_site
+/docs/changelog.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is inspired by Keep a Changelog, with the current work tracked under 
 
 ## Unreleased
 
+### Added
+
+- Added README links to the changelog and maintained AppRole examples.
+- Added a docs favicon and npm icon link in the documentation footer.
+- Added a generated documentation changelog page sourced from the root `CHANGELOG.md`.
+- Added focused v2 unit coverage for `Result` helpers, Node transport request shaping, auth edge cases, system helpers, and KV v1/v2 error handling.
+
+### Changed
+
+- Updated the package homepage to the GitHub Pages documentation site.
+- Updated the GitHub Pages workflow to generate the docs changelog before building.
+- Changed v2 AppRole login, KV v1 helpers, and high-level KV shortcut validation to return `VaultClientError` results instead of throwing synchronous exceptions.
+
 ## 2.0.0 - 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ The `tls` block supports:
 - `passphrase`
 - `rejectUnauthorized`
 
+## Examples
+
+- [AppRole example with `VaultClientV2`](examples/app-role/README.md)
+- [AppRole example with the original `VaultClient`](examples/app-role-v1/README.md)
+
 ## API
 
 For the typed v2 client, see the [VaultClientV2 API reference](https://zailic.github.io/nanvc/api-v2/).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,6 +11,7 @@ header_pages:
   - api-v1.md
   - api-v2.md
   - error-handling.md
+  - changelog.md
   - contributing.md
 
 plugins:

--- a/docs/_includes/site-footer.html
+++ b/docs/_includes/site-footer.html
@@ -12,6 +12,7 @@
         <a href="{{ '/getting-started/' | relative_url }}">Getting Started</a>
         <a href="{{ '/api-v2/' | relative_url }}">API v2</a>
         <a href="{{ '/error-handling/' | relative_url }}">Error Handling</a>
+        <a href="{{ '/changelog/' | relative_url }}">Changelog</a>
         <a href="{{ '/contributing/' | relative_url }}">Contributing</a>
       </nav>
 
@@ -25,16 +26,28 @@
 
       <div class="site-footer__aside">
         <p>Built for focused Vault workflows: app tokens, typed v2 results, KV shortcuts, and raw access when the helper surface is intentionally narrow.</p>
-        <a
-          class="site-footer__github"
-          href="https://github.com/zailic/nanvc"
-          aria-label="View nanvc on GitHub"
-          title="View on GitHub"
-        >
-          <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-            <path d="M8 0C3.58 0 0 3.73 0 8.33c0 3.68 2.29 6.8 5.47 7.9.4.08.55-.18.55-.4 0-.2-.01-.86-.01-1.56-2.01.45-2.53-.51-2.69-.98-.09-.24-.48-.98-.82-1.18-.28-.16-.68-.57-.01-.58.63-.01 1.08.6 1.23.85.72 1.28 1.87.92 2.33.7.07-.54.28-.92.51-1.13-1.78-.21-3.64-.92-3.64-4.09 0-.9.31-1.64.82-2.22-.08-.21-.36-1.06.08-2.2 0 0 .67-.22 2.2.85a7.32 7.32 0 0 1 4 0c1.53-1.07 2.2-.85 2.2-.85.44 1.14.16 1.99.08 2.2.51.58.82 1.31.82 2.22 0 3.18-1.87 3.88-3.65 4.08.29.26.54.75.54 1.52 0 1.1-.01 1.99-.01 2.26 0 .22.15.49.55.4A8.33 8.33 0 0 0 16 8.33C16 3.73 12.42 0 8 0Z"></path>
-          </svg>
-        </a>
+        <div class="site-footer__social">
+          <a
+            class="site-footer__social-link"
+            href="https://github.com/zailic/nanvc"
+            aria-label="View nanvc on GitHub"
+            title="View on GitHub"
+          >
+            <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+              <path d="M8 0C3.58 0 0 3.73 0 8.33c0 3.68 2.29 6.8 5.47 7.9.4.08.55-.18.55-.4 0-.2-.01-.86-.01-1.56-2.01.45-2.53-.51-2.69-.98-.09-.24-.48-.98-.82-1.18-.28-.16-.68-.57-.01-.58.63-.01 1.08.6 1.23.85.72 1.28 1.87.92 2.33.7.07-.54.28-.92.51-1.13-1.78-.21-3.64-.92-3.64-4.09 0-.9.31-1.64.82-2.22-.08-.21-.36-1.06.08-2.2 0 0 .67-.22 2.2.85a7.32 7.32 0 0 1 4 0c1.53-1.07 2.2-.85 2.2-.85.44 1.14.16 1.99.08 2.2.51.58.82 1.31.82 2.22 0 3.18-1.87 3.88-3.65 4.08.29.26.54.75.54 1.52 0 1.1-.01 1.99-.01 2.26 0 .22.15.49.55.4A8.33 8.33 0 0 0 16 8.33C16 3.73 12.42 0 8 0Z"></path>
+            </svg>
+          </a>
+          <a
+            class="site-footer__social-link"
+            href="https://www.npmjs.com/package/nanvc"
+            aria-label="View nanvc on npm"
+            title="View on npm"
+          >
+            <svg viewBox="0 0 18 18" aria-hidden="true" focusable="false">
+              <path d="M1 5h16v8H9v-2H7v2H1V5Zm2 2v4h2V7H3Zm4 0v2h2V7H7Zm4 0v4h2V7h-2Z"></path>
+            </svg>
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
     <meta name="description" content="{{ page.description | default: site.description }}">
+    <link rel="icon" type="image/svg+xml" href="{{ '/assets/favicon.svg' | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/css/site.css' | relative_url }}">
     {%- feed_meta -%}
   </head>

--- a/docs/assets/css/site.scss
+++ b/docs/assets/css/site.scss
@@ -533,26 +533,31 @@ ol {
   text-underline-offset: 0.18em;
 }
 
-.site-footer__github {
+.site-footer__social {
+  display: flex;
+  gap: 0.65rem;
+  margin-top: 0.95rem;
+}
+
+.site-footer__social-link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 2.75rem;
   height: 2.75rem;
-  margin-top: 0.95rem;
   border-radius: 999px;
   color: var(--accent-strong);
   background: rgba(15, 108, 92, 0.08);
   transition: transform 140ms ease, background-color 140ms ease, color 140ms ease;
 }
 
-.site-footer__github:hover {
+.site-footer__social-link:hover {
   transform: translateY(-1px);
   background: rgba(15, 108, 92, 0.14);
   color: var(--accent);
 }
 
-.site-footer__github svg {
+.site-footer__social-link svg {
   width: 1.3rem;
   height: 1.3rem;
   fill: currentColor;

--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0f6c5c"/>
+  <path d="M15 44V20h8l11 15V20h8v24h-8L23 29v15h-8Z" fill="#fffdf8"/>
+  <path d="M44 44 34 20h8l5 14 5-14h8L50 44h-6Z" fill="#d8efe8"/>
+</svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "mocha": "^11.0.0",
                 "nyc": "^18.0.0",
                 "rimraf": "^6.0.0",
+                "serialize-javascript": "^7.0.5",
                 "sinon": "^21.0.3",
                 "tsx": "^4.21.0",
                 "typescript": "^6.0.0",
@@ -869,25 +870,39 @@
             }
         },
         "node_modules/@humanfs/core": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/types": "^0.15.0"
+            },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.7",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@humanfs/core": "^0.19.1",
+                "@humanfs/core": "^0.19.2",
+                "@humanfs/types": "^0.15.0",
                 "@humanwhocodes/retry": "^0.4.0"
             },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/types": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+            "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -1036,9 +1051,9 @@
             }
         },
         "node_modules/@istanbuljs/schema": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+            "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1588,9 +1603,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.17",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
-            "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
+            "version": "2.10.20",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+            "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -1681,9 +1696,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001787",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-            "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+            "version": "1.0.30001788",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+            "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
             "dev": true,
             "funding": [
                 {
@@ -1953,9 +1968,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.334",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
-            "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
+            "version": "1.5.340",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+            "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
             "dev": true,
             "license": "ISC"
         },
@@ -2406,9 +2421,9 @@
             }
         },
         "node_modules/get-tsconfig": {
-            "version": "4.13.7",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-            "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+            "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2461,9 +2476,9 @@
             "license": "MIT"
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3055,9 +3070,9 @@
             "license": "MIT"
         },
         "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3078,6 +3093,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/mocha/node_modules/serialize-javascript": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "randombytes": "^2.1.0"
             }
         },
         "node_modules/ms": {
@@ -3231,9 +3256,9 @@
             }
         },
         "node_modules/nyc/node_modules/lru-cache": {
-            "version": "11.3.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-            "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -3755,9 +3780,9 @@
             }
         },
         "node_modules/rimraf/node_modules/lru-cache": {
-            "version": "11.3.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-            "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -3816,13 +3841,13 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/set-blocking": {
@@ -4129,9 +4154,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/lru-cache": {
-            "version": "11.3.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-            "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "type": "git",
         "url": "https://github.com/zailic/nanvc.git"
     },
-    "homepage": "https://github.com/zailic/nanvc",
+    "homepage": "https://zailic.github.io/nanvc",
     "bugs": {
         "url": "https://github.com/zailic/nanvc/issues"
     },
@@ -42,7 +42,8 @@
     },
     "scripts": {
         "clean": "rimraf dist coverage .nyc_output",
-        "docs:serve": "bundle exec jekyll serve --source docs --livereload",
+        "docs:prepare": "node ./scripts/generate-docs-changelog.mjs",
+        "docs:serve": "npm run docs:prepare && bundle exec jekyll serve --source docs --livereload",
         "generate:v2:openapi": "node ./scripts/generate-v2-openapi-types.mjs",
         "generate:v2:docs": "node ./scripts/generate-v2-docs.mjs",
         "typecheck": "tsc -p tsconfig.json",
@@ -111,6 +112,7 @@
         "sinon": "^21.0.3",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.58.0",
-        "tsx": "^4.21.0"
+        "tsx": "^4.21.0",
+        "serialize-javascript": "^7.0.5"
     }
 }

--- a/scripts/generate-docs-changelog.mjs
+++ b/scripts/generate-docs-changelog.mjs
@@ -1,0 +1,20 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { URL } from 'node:url';
+
+const sourcePath = new URL('../CHANGELOG.md', import.meta.url);
+const targetPath = new URL('../docs/changelog.md', import.meta.url);
+
+const changelog = await readFile(sourcePath, 'utf8');
+const body = changelog
+    .replace(/^# Changelog\s*/u, '')
+    .trimStart();
+
+const page = `---
+layout: page
+title: Changelog
+description: Release history and notable changes for nanvc.
+---
+
+${body}`;
+
+await writeFile(targetPath, page);

--- a/src/v2/client/auth.ts
+++ b/src/v2/client/auth.ts
@@ -2,6 +2,8 @@ import type { RawVaultClient } from '../core/raw-client.js';
 import type { Result, ResultTuple } from '../core/result.js';
 import type { components } from '../generated/vault-openapi.js';
 import { err, ok, toResult } from '../core/result.js';
+import { VaultClientError } from '../transport/errors.js';
+
 import { normalize } from 'path';
 
 export type VaultAuthMethodRequest = components['schemas']['AuthEnableMethodRequest'];
@@ -260,7 +262,11 @@ export class VaultAuthClient {
         maybePayload?: VaultAppRoleLoginRequest,
     ): Result<VaultAppRoleLoginResponse> {
         return toResult((async (): Promise<ResultTuple<VaultAppRoleLoginResponse>> => {
-            const approleRef = resolveAppRoleLoginParams(approleMountPathOrPayload, maybePayload);
+            const [approleRef, resolveError] = resolveAppRoleLoginParams(approleMountPathOrPayload, maybePayload);
+            if (resolveError) {
+                return err(resolveError);
+            }
+
             const [data, error] = await this.raw.post('/auth/{approle_mount_path}/login', {
                 body: approleRef.payload,
                 params: {
@@ -416,23 +422,26 @@ function hasVaultDataEnvelope<T>(response: T | { data?: T }): response is { data
 function resolveAppRoleLoginParams(
     approleMountPathOrPayload: string | VaultAppRoleLoginRequest,
     maybePayload?: VaultAppRoleLoginRequest,
-): {
+): ResultTuple<{
     approle_mount_path: string;
     payload: VaultAppRoleLoginRequest;
-} {
+}> {
     if (typeof approleMountPathOrPayload === 'string') {
         if (!maybePayload) {
-            throw new Error('VaultAuthClient.loginWithAppRole requires a payload object');
+            return err(new VaultClientError({
+                code: 'VALIDATION_ERROR',
+                message: 'VaultAuthClient.loginWithAppRole requires a payload object',
+            }));
         }
 
-        return {
+        return ok({
             approle_mount_path: normalize(approleMountPathOrPayload),
             payload: maybePayload,
-        };
+        });
     }
 
-    return {
+    return ok({
         approle_mount_path: 'approle',
         payload: approleMountPathOrPayload,
-    };
+    });
 }

--- a/src/v2/client/secret-kv-v1.ts
+++ b/src/v2/client/secret-kv-v1.ts
@@ -2,6 +2,7 @@ import {normalize} from 'path';
 
 import type { RawVaultClient } from '../core/raw-client.js';
 import { err, ok, toResult, type Result, type ResultTuple } from '../core/result.js';
+import { VaultClientError } from '../transport/errors.js';
 
 export class VaultSecretKvV1Client {
     constructor(private readonly raw: RawVaultClient) { }
@@ -22,7 +23,11 @@ export class VaultSecretKvV1Client {
     public delete(mount: string, path: string): Result<void>;
     public delete(pathOrMount: string, maybePath?: string): Result<void> {
         return toResult((async (): Promise<ResultTuple<void>> => {
-            const secretRef = resolveKvV1PathParams(pathOrMount, maybePath);
+            const [secretRef, resolveError] = resolveKvV1PathParams(pathOrMount, maybePath);
+            if (resolveError) {
+                return err(resolveError);
+            }
+
             const [data, error] = await this.raw.delete('/{kv_v1_mount_path}/{path}', {
                 params: {
                     path: secretRef,
@@ -53,7 +58,11 @@ export class VaultSecretKvV1Client {
     public list(mount: string, path?: string): Result<string[]>;
     public list(pathOrMount: string, maybePath?: string): Result<string[]> {
         return toResult((async (): Promise<ResultTuple<string[]>> => {
-            const secretRef = resolveKvV1PathParams(pathOrMount, maybePath, true);
+            const [secretRef, resolveError] = resolveKvV1PathParams(pathOrMount, maybePath, true);
+            if (resolveError) {
+                return err(resolveError);
+            }
+
             const [data, error] = await this.raw.list('/{kv_v1_mount_path}/{path}/', {
                 params: {
                     path: secretRef,
@@ -86,7 +95,11 @@ export class VaultSecretKvV1Client {
     public read<T = Record<string, unknown>>(mount: string, path: string): Result<T>;
     public read<T = Record<string, unknown>>(pathOrMount: string, maybePath?: string): Result<T> {
         return toResult((async (): Promise<ResultTuple<T>> => {
-            const secretRef = resolveKvV1PathParams(pathOrMount, maybePath);
+            const [secretRef, resolveError] = resolveKvV1PathParams(pathOrMount, maybePath);
+            if (resolveError) {
+                return err(resolveError);
+            }
+
             const [data, error] = await this.raw.get('/{kv_v1_mount_path}/{path}', {
                 params: {
                     path: secretRef,
@@ -124,16 +137,24 @@ export class VaultSecretKvV1Client {
         return toResult((async (): Promise<ResultTuple<void>> => {
             const payload = typeof pathOrPayload === 'string' ? maybePayload : pathOrPayload;
             if (!payload) {
-                throw new Error('VaultSecretKvV1Client.write requires a payload object');
+                return err(new VaultClientError({
+                    code: 'VALIDATION_ERROR',
+                    message: 'VaultSecretKvV1Client.write requires a payload object',
+                }));
             }
 
             const secretRef = typeof pathOrPayload === 'string'
                 ? resolveKvV1PathParams(pathOrMount, pathOrPayload)
                 : resolveKvV1PathParams(pathOrMount);
+            const [pathParams, resolveError] = secretRef;
+            if (resolveError) {
+                return err(resolveError);
+            }
+
             const [data, error] = await this.raw.post('/{kv_v1_mount_path}/{path}', {
                 body: payload,
                 params: {
-                    path: secretRef,
+                    path: pathParams,
                 },
             });
             if (error) {
@@ -150,38 +171,51 @@ function resolveKvV1PathParams(
     pathOrMount: string,
     maybePath?: string,
     allowEmptyPath = false,
-): {
+): ResultTuple<{
     kv_v1_mount_path: string;
     path: string;
-} {
+}> {
     if (typeof maybePath === 'string') {
         const kv_v1_mount_path = normalize(pathOrMount);
         const path = normalize(maybePath);
 
         if (!kv_v1_mount_path) {
-            throw new Error(`Expected a KV v1 mount path, got "${pathOrMount}"`);
+            return err(new VaultClientError({
+                code: 'VALIDATION_ERROR',
+                message: `Expected a KV v1 mount path, got "${pathOrMount}"`,
+            }));
         }
 
         if (!allowEmptyPath && !path) {
-            throw new Error(`Expected a KV v1 secret path, got "${maybePath}"`);
+            return err(new VaultClientError({
+                code: 'VALIDATION_ERROR',
+                message: `Expected a KV v1 secret path, got "${maybePath}"`,
+            }));
         }
 
-        return {
+        return ok({
             kv_v1_mount_path,
             path,
-        };
+        });
     }
 
     const normalizedPath = normalize(pathOrMount);
     const [kv_v1_mount_path, ...segments] = normalizedPath.split('/').filter(Boolean);
     const path = segments.join('/');
 
-    if (!kv_v1_mount_path || (!allowEmptyPath && path.length === 0)) {
-        throw new Error(`Expected a KV v1 secret path like "secret/my-app/my-secret", got "${pathOrMount}"`);
+    if (
+        !kv_v1_mount_path || 
+        kv_v1_mount_path === '.' || 
+        (!allowEmptyPath && path.length === 0)
+    ) {
+        return err(new VaultClientError({
+            code: 'VALIDATION_ERROR',
+            message: `Expected a KV v1 secret path like "secret/my-app/my-secret", got "${pathOrMount}"`,
+        }));
     }
 
-    return {
+    return ok({
         kv_v1_mount_path,
         path,
-    };
+    });
 }

--- a/src/v2/client/vault-client.ts
+++ b/src/v2/client/vault-client.ts
@@ -1,5 +1,6 @@
 import { RawVaultClient } from '../core/raw-client.js';
-import type { Result } from '../core/result.js';
+import { err, ok, toResult, type Result, type ResultTuple } from '../core/result.js';
+import { VaultClientError } from '../transport/errors.js';
 import type { VaultClientOptions } from '../transport/types.js';
 import { VaultAuthClient } from './auth.js';
 import { VaultSecretClient } from './secret.js';
@@ -55,7 +56,12 @@ export class VaultClient {
         pathOrOptions?: string | VaultKvShortcutDeleteOptions,
         maybeOptions?: VaultKvShortcutDeleteOptions,
     ): Result<void> {
-        const { mount, path, options } = resolveKvShortcutRef(pathOrMount, pathOrOptions, maybeOptions);
+        const [ref, resolveError] = resolveKvShortcutRef(pathOrMount, pathOrOptions, maybeOptions);
+        if (resolveError) {
+            return errorResult(resolveError);
+        }
+
+        const { mount, path, options } = ref;
 
         if (isKvV2Shortcut(options)) {
             return this.secret.kv.v2.delete(mount, path);
@@ -75,7 +81,12 @@ export class VaultClient {
         pathOrOptions?: string | VaultKvShortcutListOptions,
         maybeOptions?: VaultKvShortcutListOptions,
     ): Result<string[]> {
-        const { mount, path, options } = resolveKvShortcutRef(pathOrMount, pathOrOptions, maybeOptions, true);
+        const [ref, resolveError] = resolveKvShortcutRef(pathOrMount, pathOrOptions, maybeOptions, true);
+        if (resolveError) {
+            return errorResult(resolveError);
+        }
+
+        const { mount, path, options } = ref;
 
         if (isKvV2Shortcut(options)) {
             return this.secret.kv.v2.list(mount, path);
@@ -106,7 +117,12 @@ export class VaultClient {
         pathOrOptions?: string | VaultKvShortcutReadOptions,
         maybeOptions?: VaultKvShortcutReadOptions,
     ): Result<T | VaultKvV2ReadResponse<T>> {
-        const { mount, path, options } = resolveKvShortcutRef(pathOrMount, pathOrOptions, maybeOptions);
+        const [ref, resolveError] = resolveKvShortcutRef(pathOrMount, pathOrOptions, maybeOptions);
+        if (resolveError) {
+            return errorResult(resolveError);
+        }
+
+        const { mount, path, options } = ref;
 
         if (isKvV2Shortcut(options)) {
             return this.secret.kv.v2.read<T>(mount, path, {
@@ -150,14 +166,22 @@ export class VaultClient {
         const payload = typeof pathOrPayload === 'string' ? payloadOrOptions : pathOrPayload;
 
         if (!isRecord(payload)) {
-            throw new Error('VaultClient.write requires a payload object');
+            return errorResult(new VaultClientError({
+                code: 'VALIDATION_ERROR',
+                message: 'VaultClient.write requires a payload object',
+            }));
         }
 
-        const { mount, path, options } = resolveKvShortcutRef(
+        const [ref, resolveError] = resolveKvShortcutRef(
             pathOrMount,
             typeof pathOrPayload === 'string' ? pathOrPayload : payloadOrOptions as VaultKvShortcutWriteOptions | undefined,
             maybeOptions,
         );
+        if (resolveError) {
+            return errorResult(resolveError);
+        }
+
+        const { mount, path, options } = ref;
 
         if (isKvV2Shortcut(options)) {
             const writeOptions = options as VaultKvShortcutV2WriteOptions;
@@ -177,31 +201,34 @@ function resolveKvShortcutRef<TOptions extends VaultKvShortcutReadOptions>(
     pathOrOptions?: string | TOptions,
     maybeOptions?: TOptions,
     allowEmptyPath = false,
-): {
+): ResultTuple<{
     mount: string;
     options?: TOptions;
     path: string;
-} {
+}> {
     if (typeof pathOrOptions === 'string') {
-        return {
+        return ok({
             mount: pathOrMount,
             options: maybeOptions,
             path: pathOrOptions,
-        };
+        });
     }
 
     const [mount, ...pathSegments] = pathOrMount.split('/').filter(Boolean);
     const path = pathSegments.join('/');
 
     if (!mount || (!allowEmptyPath && !path)) {
-        throw new Error(`Expected a KV secret path like "secret/my-app/my-secret", got "${pathOrMount}"`);
+        return err(new VaultClientError({
+            code: 'VALIDATION_ERROR',
+            message: `Expected a KV secret path like "secret/my-app/my-secret", got "${pathOrMount}"`,
+        }));
     }
 
-    return {
+    return ok({
         mount,
         options: pathOrOptions,
         path,
-    };
+    });
 }
 
 function isKvV2Shortcut(options: VaultKvShortcutReadOptions | undefined): options is VaultKvShortcutV2ReadOptions {
@@ -210,4 +237,8 @@ function isKvV2Shortcut(options: VaultKvShortcutReadOptions | undefined): option
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function errorResult<T>(error: VaultClientError): Result<T> {
+    return toResult(Promise.resolve(err(error) as ResultTuple<T>));
 }

--- a/test/unit/v2/auth.ts
+++ b/test/unit/v2/auth.ts
@@ -6,6 +6,7 @@ import { RawVaultClient } from '../../../src/v2/core/raw-client.js';
 import { VaultClientError } from '../../../src/v2/transport/errors.js';
 import { err, ok, toResult } from '../../../src/v2/core/result.js';
 
+import type { VaultAppRoleLoginRequest } from '../../../src/v2/client/auth.js';
 import type { SinonSandbox } from 'sinon';
 
 describe('VaultAuthClient unit test cases.', function () {
@@ -57,6 +58,29 @@ describe('VaultAuthClient unit test cases.', function () {
             },
         });
     });
+
+    it('should surface errors from Vault when enabling an auth method', async function () {
+        const clientError = new VaultClientError({
+            code: 'HTTP_ERROR',
+            message: 'Forbidden',
+            status: 403,
+        });
+        sandbox.stub(RawVaultClient.prototype, 'post').returns(
+            resultOf(err(clientError)),
+        );
+        const client = new VaultAuthClient(new RawVaultClient());
+
+        await assert.rejects(
+            client.enableAuthMethod('team/auth/approle', {
+                type: 'approle',
+            }).unwrap(),
+            (error: unknown) => {
+                assert.equal(error, clientError);
+                return true;
+            },
+        );
+    });
+
 
     it('should skip enabling an auth method when it already exists', async function () {
         sandbox.stub(RawVaultClient.prototype, 'get').returns(
@@ -225,6 +249,41 @@ describe('VaultAuthClient unit test cases.', function () {
         });
     });
 
+    it('should defensively return an AppRole role id response when no Vault data envelope exists', async function () {
+        sandbox.stub(RawVaultClient.prototype, 'get').returns(
+            resultOf(ok({
+                role_id: 'role-id-value',
+            })),
+        );
+        const client = new VaultAuthClient(new RawVaultClient());
+
+        const roleId = await client.getAppRoleRoleId('jenkins').unwrap();
+
+        assert.deepEqual(roleId, {
+            role_id: 'role-id-value',
+        });
+    });
+
+    it('should surface errors from Vault when reading an AppRole role id', async function () {
+        const clientError = new VaultClientError({
+            cause: new Error('Network Error'),
+            code: 'NETWORK_ERROR',
+            message: 'Simulated network error',
+        });
+        sandbox.stub(RawVaultClient.prototype, 'get').returns(
+            resultOf(err(clientError)),
+        );
+        const client = new VaultAuthClient(new RawVaultClient());
+
+        await assert.rejects(
+            client.getAppRoleRoleId('jenkins').unwrap(),
+            (error: unknown) => {
+                assert.equal(error, clientError);
+                return true;
+            },
+        );
+    });
+
     it('should register an AppRole role id on a custom approle mount', async function () {
         const postStub = sandbox.stub(RawVaultClient.prototype, 'post').returns(
             resultOf(ok(undefined)),
@@ -250,6 +309,26 @@ describe('VaultAuthClient unit test cases.', function () {
                 },
             },
         });
+    });
+
+    it('should surface errors from Vault when registering an AppRole role id', async function () {
+        const clientError = new VaultClientError({
+            cause: new Error('Network Error'),
+            code: 'NETWORK_ERROR',
+            message: 'Simulated network error',
+        });
+        sandbox.stub(RawVaultClient.prototype, 'post').returns(
+            resultOf(err(clientError)),
+        );
+        const client = new VaultAuthClient(new RawVaultClient());
+
+        await assert.rejects(
+            client.registerAppRoleRoleId('/team/approle', '/jenkins', { role_id: 'custom-role-id' }).unwrap(),
+            (error: unknown) => {
+                assert.equal(error, clientError);
+                return true;
+            },
+        );
     });
 
     it('should generate an AppRole secret id from the default approle mount', async function () {
@@ -314,6 +393,26 @@ describe('VaultAuthClient unit test cases.', function () {
                 },
             },
         });
+    });
+
+    it('should surface network errors when generating an AppRole secret id', async function () {
+        const clientError = new VaultClientError({
+            cause: new Error('Network Error'),
+            code: 'NETWORK_ERROR',
+            message: 'Simulated network error',
+        });
+        sandbox.stub(RawVaultClient.prototype, 'post').returns(
+            resultOf(err(clientError)),
+        );
+        const client = new VaultAuthClient(new RawVaultClient());
+        
+        await assert.rejects(
+            client.generateAppRoleSecretId('jenkins', { ttl: '30m' }).unwrap(),
+            (error: unknown) => {
+                assert.equal(error, clientError);
+                return true;
+            },
+        );
     });
 
     it('should login with AppRole on the default approle mount and set the raw token', async function () {
@@ -470,4 +569,29 @@ describe('VaultAuthClient unit test cases.', function () {
             },
         );
     });
+    
+    it('should surface validation errors when payload is not specified for loginWithAppRole', async function () {
+        const postStub = sandbox.stub(RawVaultClient.prototype, 'post').returns(
+            resultOf(ok(undefined)),
+        );
+        const client = new VaultAuthClient(new RawVaultClient());
+
+        const [data, error] = await client.loginWithAppRole('team/approle', undefined as unknown as VaultAppRoleLoginRequest);
+
+        assert.equal(data, null);
+        assert.equal(error instanceof VaultClientError, true);
+        assert.equal(error?.code, 'VALIDATION_ERROR');
+        assert.equal(error?.message, 'VaultAuthClient.loginWithAppRole requires a payload object');
+        assert.equal(postStub.called, false);
+        await assert.rejects(
+            client.loginWithAppRole('team/approle', undefined as unknown as VaultAppRoleLoginRequest).unwrap(),
+            (err: unknown) => {
+                assert.equal(err instanceof VaultClientError, true);
+                assert.equal((err as VaultClientError).code, 'VALIDATION_ERROR');
+                assert.equal((err as VaultClientError).message, 'VaultAuthClient.loginWithAppRole requires a payload object');
+                return true;
+            },
+        );
+    });
+
 });

--- a/test/unit/v2/node-transport.ts
+++ b/test/unit/v2/node-transport.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+
+import { NodeVaultTransport } from '../../../src/v2/transport/node-transport.js';
+
+describe('NodeVaultTransport unit test cases.', function () {
+    it('should build URLs from explicit options with LIST and query parameters', function () {
+        const transport = new NodeVaultTransport({
+            apiVersion: 'v2',
+            clusterAddress: 'https://vault.example.test/',
+        });
+
+        const url = getPrivate<URL>(transport, 'buildUrl', {
+            method: 'LIST',
+            path: '/secret/apps',
+            query: {
+                limit: 10,
+                optional: undefined,
+                recurse: true,
+            },
+        });
+
+        assert.equal(url.toString(), 'https://vault.example.test/v2/secret/apps?list=true&limit=10&recurse=true');
+    });
+
+    it('should build URLs from environment defaults when options are omitted', function () {
+        const originalClusterAddress = process.env.NANVC_VAULT_CLUSTER_ADDRESS;
+        const originalApiVersion = process.env.NANVC_VAULT_API_VERSION;
+        process.env.NANVC_VAULT_CLUSTER_ADDRESS = 'http://vault.local:8200/';
+        process.env.NANVC_VAULT_API_VERSION = 'v3';
+
+        try {
+            const transport = new NodeVaultTransport();
+
+            const url = getPrivate<URL>(transport, 'buildUrl', {
+                method: 'GET',
+                path: '/sys/health',
+            });
+
+            assert.equal(url.toString(), 'http://vault.local:8200/v3/sys/health');
+        } finally {
+            restoreEnv('NANVC_VAULT_CLUSTER_ADDRESS', originalClusterAddress);
+            restoreEnv('NANVC_VAULT_API_VERSION', originalApiVersion);
+        }
+    });
+
+    it('should build request options with JSON body headers and tokens', function () {
+        const transport = new NodeVaultTransport();
+        const url = new URL('http://127.0.0.1:8200/v1/secret/apps?list=true');
+
+        const options = getPrivate<Record<string, unknown>>(transport, 'buildRequestOptions', url, {
+            headers: { 'X-Custom': 'custom' },
+            method: 'LIST',
+            path: 'secret/apps',
+            token: 'vault-token',
+        }, '{"hello":"vault"}');
+
+        assert.equal(options.method, 'GET');
+        assert.equal(options.path, '/v1/secret/apps?list=true');
+        assert.equal(options.port, 8200);
+        assert.deepEqual(options.headers, {
+            Accept: 'application/json',
+            'Content-Length': '17',
+            'Content-Type': 'application/json',
+            'X-Custom': 'custom',
+            'X-Vault-Token': 'vault-token',
+        });
+    });
+
+    it('should apply TLS options only for HTTPS URLs', function () {
+        const transport = new NodeVaultTransport({
+            tls: {
+                ca: 'ca',
+                cert: 'cert',
+                key: 'key',
+                passphrase: 'secret',
+                rejectUnauthorized: false,
+            },
+        });
+
+        const httpsOptions = getPrivate<Record<string, unknown>>(transport, 'buildRequestOptions', new URL('https://vault.local/v1/sys/health'), {
+            method: 'GET',
+            path: 'sys/health',
+        });
+        const httpOptions = getPrivate<Record<string, unknown>>(transport, 'buildRequestOptions', new URL('http://vault.local/v1/sys/health'), {
+            method: 'GET',
+            path: 'sys/health',
+        });
+
+        assert.equal(httpsOptions.ca, 'ca');
+        assert.equal(httpsOptions.cert, 'cert');
+        assert.equal(httpsOptions.key, 'key');
+        assert.equal(httpsOptions.passphrase, 'secret');
+        assert.equal(httpsOptions.rejectUnauthorized, false);
+        assert.equal('ca' in httpOptions, false);
+        assert.equal('cert' in httpOptions, false);
+        assert.equal('key' in httpOptions, false);
+    });
+});
+
+function getPrivate<T>(
+    transport: NodeVaultTransport,
+    method: 'buildRequestOptions' | 'buildUrl',
+    ...args: unknown[]
+): T {
+    return (transport as unknown as Record<string, (...methodArgs: unknown[]) => T>)[method](...args);
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+    if (value === undefined) {
+        delete process.env[name];
+        return;
+    }
+
+    process.env[name] = value;
+}

--- a/test/unit/v2/result.ts
+++ b/test/unit/v2/result.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+
+import { err, ok, toResult } from '../../../src/v2/core/result.js';
+
+describe('Result helper unit test cases.', function () {
+    it('should return tuple helpers for ok and err values', function () {
+        assert.deepEqual(ok({ value: 1 }), [{ value: 1 }, null]);
+        assert.deepEqual(err(new Error('failed')), [null, new Error('failed')]);
+    });
+
+    it('should return successful values from fallback helpers', async function () {
+        const result = toResult(Promise.resolve(ok('value')));
+
+        assert.equal(await result.unwrapOr('fallback'), 'value');
+        assert.equal(await result.unwrapOrElse(() => 'fallback'), 'value');
+        assert.equal(await result.intoErr(), null);
+    });
+
+    it('should return fallback values for failed results', async function () {
+        const cause = new Error('failed');
+        const result = toResult<string, Error>(Promise.resolve(err(cause)));
+
+        assert.equal(await result.unwrapOr('fallback'), 'fallback');
+        assert.equal(await result.unwrapOrElse((error) => error.message), 'failed');
+        assert.equal(await result.unwrapErr(), cause);
+        assert.equal(await result.intoErr(), cause);
+    });
+
+    it('should reject unwrapErr on successful results', async function () {
+        const result = toResult(Promise.resolve(ok('value')));
+
+        await assert.rejects(
+            result.unwrapErr(),
+            /Called unwrapErr on an Ok value/,
+        );
+    });
+});

--- a/test/unit/v2/vault-client.ts
+++ b/test/unit/v2/vault-client.ts
@@ -147,6 +147,145 @@ describe('VaultClientV2 unit test cases.', function () {
         assert.equal(ready, false);
     });
 
+    it('should surface non-HTTP readiness errors', async function () {
+        const clientError = new VaultClientError({
+            code: 'NETWORK_ERROR',
+            message: 'connection refused',
+        });
+        sandbox.stub(RawVaultClient.prototype, 'request').returns(
+            resultOf(err(clientError)),
+        );
+        const client = new VaultClient();
+
+        await assert.rejects(
+            client.sys.isReady().unwrap(),
+            (error: unknown) => {
+                assert.equal(error, clientError);
+                return true;
+            },
+        );
+    });
+
+    it('should route system mount enable and disable calls', async function () {
+        const postStub = sandbox.stub(RawVaultClient.prototype, 'post').returns(
+            resultOf(ok(undefined)),
+        );
+        const deleteStub = sandbox.stub(RawVaultClient.prototype, 'delete').returns(
+            resultOf(ok(undefined)),
+        );
+        const client = new VaultClient();
+
+        const [enableData, enableError] = await client.sys.mount.enable('/secret/', {
+            type: 'kv',
+        });
+        const [disableData, disableError] = await client.sys.mount.disable('/secret/');
+
+        assert.equal(enableData, undefined);
+        assert.equal(enableError, null);
+        assert.equal(disableData, undefined);
+        assert.equal(disableError, null);
+        assert.deepEqual(postStub.firstCall.args, [
+            '/sys/mounts/{path}',
+            {
+                body: {
+                    type: 'kv',
+                },
+                params: {
+                    path: {
+                        path: '/secret/',
+                    },
+                },
+            },
+        ]);
+        assert.deepEqual(deleteStub.firstCall.args, [
+            '/sys/mounts/{path}',
+            {
+                params: {
+                    path: {
+                        path: '/secret/',
+                    },
+                },
+            },
+        ]);
+    });
+
+    it('should surface system mount errors', async function () {
+        const clientError = new VaultClientError({
+            code: 'HTTP_ERROR',
+            message: 'missing permission',
+            status: 403,
+        });
+        sandbox.stub(RawVaultClient.prototype, 'post').returns(
+            resultOf(err(clientError)),
+        );
+        const client = new VaultClient();
+
+        await assert.rejects(
+            client.sys.mount.enable('secret', { type: 'kv' }).unwrap(),
+            (error: unknown) => {
+                assert.equal(error, clientError);
+                return true;
+            },
+        );
+    });
+
+    it('should not set a token when init returns no root token', async function () {
+        sandbox.stub(RawVaultClient.prototype, 'post').returns(
+            resultOf(ok({
+                keys: ['unseal-key'],
+            })),
+        );
+        const setTokenSpy = sandbox.spy(RawVaultClient.prototype, 'setToken');
+        const client = new VaultClient();
+
+        const initData = await client.sys.init({
+            secret_shares: 1,
+            secret_threshold: 1,
+        }).unwrap();
+
+        assert.deepEqual(initData, {
+            keys: ['unseal-key'],
+        });
+        assert.equal(setTokenSpy.called, false);
+    });
+
+    it('should route seal status and unseal calls', async function () {
+        const getStub = sandbox.stub(RawVaultClient.prototype, 'get').returns(
+            resultOf(ok({
+                initialized: true,
+                sealed: true,
+            })),
+        );
+        const postStub = sandbox.stub(RawVaultClient.prototype, 'post').returns(
+            resultOf(ok({
+                sealed: false,
+            })),
+        );
+        const client = new VaultClient();
+
+        const sealStatus = await client.sys.sealStatus().unwrap();
+        const unsealStatus = await client.sys.unseal({
+            key: 'unseal-key',
+        }).unwrap();
+
+        assert.deepEqual(sealStatus, {
+            initialized: true,
+            sealed: true,
+        });
+        assert.deepEqual(unsealStatus, {
+            sealed: false,
+        });
+        assert.deepEqual(getStub.firstCall.args, ['/sys/seal-status']);
+        assert.deepEqual(postStub.firstCall.args, [
+            '/sys/unseal',
+            {
+                body: {
+                    key: 'unseal-key',
+                },
+            },
+        ]);
+    });
+
     it('should route kv2 writes through the mount data path with wrapped payload', async function () {
         const postStub = sandbox.stub(RawVaultClient.prototype, 'post').returns(
             resultOf(ok(undefined)),
@@ -228,6 +367,44 @@ describe('VaultClientV2 unit test cases.', function () {
                 version: 1,
             },
         });
+    });
+
+    it('should not unwrap kv2 read errors that are not soft-deleted secret responses', async function () {
+        const forbiddenError = new VaultClientError({
+            code: 'HTTP_ERROR',
+            message: 'Forbidden',
+            responseBody: {
+                data: {
+                    metadata: {
+                        destroyed: false,
+                    },
+                },
+            },
+            status: 403,
+        });
+        const missingEnvelopeError = new VaultClientError({
+            code: 'HTTP_ERROR',
+            message: 'Not Found',
+            responseBody: {
+                errors: ['not found'],
+            },
+            status: 404,
+        });
+        const unknownError = new Error('socket closed') as VaultClientError;
+        const getStub = sandbox.stub(RawVaultClient.prototype, 'get');
+        getStub.onFirstCall().returns(resultOf(err(forbiddenError)));
+        getStub.onSecondCall().returns(resultOf(err(missingEnvelopeError)));
+        getStub.onThirdCall().returns(resultOf(err(unknownError)));
+        const client = new VaultClient();
+
+        const [, forbiddenResult] = await client.secret.kv.v2.read('secret-v2', 'apps/forbidden');
+        const [, missingEnvelopeResult] = await client.secret.kv.v2.read('secret-v2', 'apps/missing-envelope');
+        const [, unknownResult] = await client.secret.kv.v2.read('secret-v2', 'apps/unknown');
+
+        assert.equal(forbiddenResult, forbiddenError);
+        assert.equal(missingEnvelopeResult, missingEnvelopeError);
+        assert.equal(unknownResult, unknownError);
+        assert.equal(getStub.callCount, 3);
     });
 
     it('should list kv2 keys through the metadata path', async function () {
@@ -328,6 +505,189 @@ describe('VaultClientV2 unit test cases.', function () {
                 },
             },
         ]);
+    });
+
+    it('should return validation errors for invalid kv1 paths', async function () {
+        const getStub = sandbox.stub(RawVaultClient.prototype, 'get').returns(
+            resultOf(ok({ data: {} })),
+        );
+        const client = new VaultClient();
+
+        const [readData, readError] = await client.secret.kv.v1.read('secret');
+
+        assert.equal(readData, null);
+        assert.equal(readError instanceof VaultClientError, true);
+        assert.equal(readError?.code, 'VALIDATION_ERROR');
+        assert.equal(readError?.message, 'Expected a KV v1 secret path like "secret/my-app/my-secret", got "secret"');
+        assert.equal(getStub.called, false);
+    });
+
+    it('should return validation errors for missing kv1 write payloads', async function () {
+        const postStub = sandbox.stub(RawVaultClient.prototype, 'post').returns(
+            resultOf(ok(undefined)),
+        );
+        const client = new VaultClient();
+
+        const [data, error] = await client.secret.kv.v1.write('secret', 'apps/demo', undefined as unknown as Record<string, unknown>);
+
+        assert.equal(data, null);
+        assert.equal(error instanceof VaultClientError, true);
+        assert.equal(error?.code, 'VALIDATION_ERROR');
+        assert.equal(error?.message, 'VaultSecretKvV1Client.write requires a payload object');
+        assert.equal(postStub.called, false);
+    });
+
+    it('should allow empty kv1 paths only for list operations', async function () {
+        const listStub = sandbox.stub(RawVaultClient.prototype, 'list').returns(
+            resultOf(ok({
+                keys: ['apps/'],
+            })),
+        );
+        const client = new VaultClient();
+
+        const keys = await client.secret.kv.v1.list('secret').unwrap();
+
+        assert.deepEqual(keys, ['apps/']);
+        assert.deepEqual(listStub.firstCall.args, [
+            '/{kv_v1_mount_path}/{path}/',
+            {
+                params: {
+                    path: {
+                        kv_v1_mount_path: 'secret',
+                        path: '',
+                    },
+                    query: {
+                        list: 'true',
+                    },
+                },
+            },
+        ]);
+    });
+
+    it('should surface validation errors for invalid kv1 paths', async function () {
+        const client = new VaultClient();
+        const deleteStub = sandbox.stub(RawVaultClient.prototype, 'delete').returns(
+            resultOf(ok(undefined)),
+        );
+
+        const [deleteData, deleteError] = await client.secret.kv.v1.delete('secret');
+
+        assert.equal(deleteData, null);
+        assert.equal(deleteError instanceof VaultClientError, true);
+        assert.equal(deleteError?.code, 'VALIDATION_ERROR');
+        assert.equal(deleteError?.message, 'Expected a KV v1 secret path like "secret/my-app/my-secret", got "secret"');
+        assert.equal(deleteStub.called, false);
+
+        const listStub = sandbox.stub(RawVaultClient.prototype, 'list').returns(
+            resultOf(ok({
+                keys: ['apps/'],
+            })),
+        );
+
+        const [keys, listError] = await client.secret.kv.v1.list('');
+
+        assert.equal(keys, null);
+        assert.equal(listError instanceof VaultClientError, true);
+        assert.equal(listError?.code, 'VALIDATION_ERROR');
+        assert.equal(listError?.message, 'Expected a KV v1 secret path like "secret/my-app/my-secret", got ""');
+        assert.equal(listStub.called, false);
+
+        const getStub = sandbox.stub(RawVaultClient.prototype, 'get').returns(
+            resultOf(ok({ data: {} })),
+        );
+        
+        const [readData, readError] = await client.secret.kv.v1.read('secret');
+
+        assert.equal(readData, null);
+        assert.equal(readError instanceof VaultClientError, true);
+        assert.equal(readError?.code, 'VALIDATION_ERROR');
+        assert.equal(readError?.message, 'Expected a KV v1 secret path like "secret/my-app/my-secret", got "secret"');
+        assert.equal(getStub.called, false);
+
+        const postStub = sandbox.stub(RawVaultClient.prototype, 'post').returns(
+            resultOf(ok(undefined)),
+        );
+        
+        const [writeData, writeError] = await client.secret.kv.v1.write('secret', {});
+
+        assert.equal(writeData, null);
+        assert.equal(writeError instanceof VaultClientError, true);
+        assert.equal(writeError?.code, 'VALIDATION_ERROR');
+        assert.equal(writeError?.message, 'Expected a KV v1 secret path like "secret/my-app/my-secret", got "secret"');
+        assert.equal(postStub.called, false);
+    });
+
+    it('should surface raw client errors from kv1 shortcut methods', async function () {
+        const clientError = new VaultClientError({
+            code: 'HTTP_ERROR',
+            message: 'Vault said no',
+            status: 403,
+        });
+        const getStub = sandbox.stub(RawVaultClient.prototype, 'get').returns(
+            resultOf(err(clientError)),
+        );
+        const client = new VaultClient();
+
+        const [readData, readError] = await client.secret.kv.v1.read('secret/apps/demo');
+
+        assert.equal(readData, null);
+        assert.equal(readError, clientError);
+        assert.equal(getStub.calledOnce, true);
+
+        const deleteStub = sandbox.stub(RawVaultClient.prototype, 'delete').returns(
+            resultOf(err(clientError)),
+        );
+
+        const [deleteData, deleteError] = await client.secret.kv.v1.delete('secret/apps/demo');
+
+        assert.equal(deleteData, null);
+        assert.equal(deleteError, clientError);
+        assert.equal(deleteStub.calledOnce, true);
+
+        const postStub = sandbox.stub(RawVaultClient.prototype, 'post').returns(
+            resultOf(err(clientError)),
+        );
+
+        const [writeData, writeError] = await client.secret.kv.v1.write('secret/apps/demo', { foo: 'bar' });
+
+        assert.equal(writeData, null);
+        assert.equal(writeError, clientError);
+        assert.equal(postStub.calledOnce, true);
+
+        const listStub = sandbox.stub(RawVaultClient.prototype, 'list').returns(
+            resultOf(err(clientError)),
+        );
+
+        const [keys, listError] = await client.secret.kv.v1.list('secret/apps');
+
+        assert.equal(keys, null);
+        assert.equal(listError, clientError);
+        assert.equal(listStub.calledOnce, true);
+
+    });
+
+    it('should return validation errors from invalid high-level kv shortcuts', async function () {
+        const client = new VaultClient();
+        const getStub = sandbox.stub(RawVaultClient.prototype, 'get').returns(
+            resultOf(ok({ data: {} })),
+        );
+        const postStub = sandbox.stub(RawVaultClient.prototype, 'post').returns(
+            resultOf(ok(undefined)),
+        );
+
+        const [readData, readError] = await client.read('secret');
+        const [writeData, writeError] = await client.write('secret/apps/demo', undefined as unknown as Record<string, unknown>);
+
+        assert.equal(readData, null);
+        assert.equal(readError instanceof VaultClientError, true);
+        assert.equal(readError?.code, 'VALIDATION_ERROR');
+        assert.equal(readError?.message, 'Expected a KV secret path like "secret/my-app/my-secret", got "secret"');
+        assert.equal(writeData, null);
+        assert.equal(writeError instanceof VaultClientError, true);
+        assert.equal(writeError?.code, 'VALIDATION_ERROR');
+        assert.equal(writeError?.message, 'VaultClient.write requires a payload object');
+        assert.equal(getStub.called, false);
+        assert.equal(postStub.called, false);
     });
 
     it('should expose kv1 shortcut methods on the high-level client', async function () {
@@ -490,5 +850,53 @@ describe('VaultClientV2 unit test cases.', function () {
                 },
             },
         });
+    });
+
+    it('should surface raw client errors from kv2 shortcut methods', async function () {
+        const clientError = new VaultClientError({
+            code: 'HTTP_ERROR',
+            message: 'Vault said no',
+            status: 403,
+        });
+        const getStub = sandbox.stub(RawVaultClient.prototype, 'get').returns(
+            resultOf(err(clientError)),
+        );
+        const client = new VaultClient();
+
+        const [readData, readError] = await client.secret.kv.v2.read('secret-v2', 'apps/demo');
+
+        assert.equal(readData, null);
+        assert.equal(readError, clientError);
+        assert.equal(getStub.calledOnce, true);
+
+        const deleteStub = sandbox.stub(RawVaultClient.prototype, 'delete').returns(
+            resultOf(err(clientError)),
+        );
+
+        const [deleteData, deleteError] = await client.secret.kv.v2.delete('secret-v2', 'apps/demo');
+
+        assert.equal(deleteData, null);
+        assert.equal(deleteError, clientError);
+        assert.equal(deleteStub.calledOnce, true);
+
+        const postStub = sandbox.stub(RawVaultClient.prototype, 'post').returns(
+            resultOf(err(clientError)),
+        );
+
+        const [writeData, writeError] = await client.secret.kv.v2.write('secret-v2', 'apps/demo', { foo: 'bar' });
+
+        assert.equal(writeData, null);
+        assert.equal(writeError, clientError);
+        assert.equal(postStub.calledOnce, true);
+
+        const listStub = sandbox.stub(RawVaultClient.prototype, 'list').returns(
+            resultOf(err(clientError)),
+        );
+
+        const [keys, listError] = await client.secret.kv.v2.list('secret-v2', 'apps');
+
+        assert.equal(keys, null);
+        assert.equal(listError, clientError);
+        assert.equal(listStub.calledOnce, true);
     });
 });


### PR DESCRIPTION
This pull request introduces several improvements to the documentation workflow, user-facing documentation, and error handling for the v2 client. The main highlights include generating a dedicated changelog page from the root `CHANGELOG.md`, adding new links and icons to the docs footer, and refactoring AppRole, KV v1, and shortcut helpers to return structured `VaultClientError` results for validation errors instead of throwing exceptions.

**Documentation workflow and site improvements:**

* Added a script (`scripts/generate-docs-changelog.mjs`) and workflow steps to generate a `docs/changelog.md` page from the root `CHANGELOG.md`, and updated the documentation site to link to the new changelog. Also added a favicon and npm icon link to the docs footer. [[1]](diffhunk://#diff-86eaae8c6d4108350f0ef9589ef2a19de3d6e3693eff3b89ee35c160ae35c21cR9-R13) [[2]](diffhunk://#diff-86eaae8c6d4108350f0ef9589ef2a19de3d6e3693eff3b89ee35c160ae35c21cR45-R47) [[3]](diffhunk://#diff-f64371f310bcd3bbf6ead5827d929a4eb13b7516806d6658485a996e39eb2556R14) [[4]](diffhunk://#diff-9cbca53aa5b0e8e2c98877fd67c4131b6eb6a1c1df6704a602ee51992434b3efR15) [[5]](diffhunk://#diff-9cbca53aa5b0e8e2c98877fd67c4131b6eb6a1c1df6704a602ee51992434b3efR29-R31) [[6]](diffhunk://#diff-9cbca53aa5b0e8e2c98877fd67c4131b6eb6a1c1df6704a602ee51992434b3efR40-R50) [[7]](diffhunk://#diff-ddb6373434059f8e97028b6be1bf40dea40384f654e85dabafcea168458db8d0R8) [[8]](diffhunk://#diff-6d5f3c5fc1c3a0f96046c8841874d758deefbeae3f5cf1a8c5fd77e820fb04d7R1-R20) [[9]](diffhunk://#diff-6e44737cd29deaf11f5d2d4448acc7e1ee50b8353e680b907190b9db3896e1f4L536-R560)
* Updated the package homepage in `package.json` to point to the GitHub Pages documentation site.
* Added new README links to AppRole examples.

**Changelog and coverage:**

* Updated `CHANGELOG.md` with new features, documentation changes, and error handling improvements.

**Error handling and v2 client improvements:**

* Refactored v2 AppRole login, KV v1 helpers, and high-level KV shortcut validation to return `VaultClientError` results on validation errors, rather than throwing synchronous exceptions. This affects `src/v2/client/auth.ts`, `src/v2/client/secret-kv-v1.ts`, and `src/v2/client/vault-client.ts`. [[1]](diffhunk://#diff-c4eb272c707a850b386edd433ff998ac310fd886b8b37cc837f4176297bfcd12L263-R269) [[2]](diffhunk://#diff-c4eb272c707a850b386edd433ff998ac310fd886b8b37cc837f4176297bfcd12L419-R446) [[3]](diffhunk://#diff-76f477baa8064d13dbb8e799b39ffe3880601dc64209abdffe13d53bd54efca4L25-R30) [[4]](diffhunk://#diff-76f477baa8064d13dbb8e799b39ffe3880601dc64209abdffe13d53bd54efca4L56-R65) [[5]](diffhunk://#diff-76f477baa8064d13dbb8e799b39ffe3880601dc64209abdffe13d53bd54efca4L89-R102) [[6]](diffhunk://#diff-76f477baa8064d13dbb8e799b39ffe3880601dc64209abdffe13d53bd54efca4L127-R157) [[7]](diffhunk://#diff-76f477baa8064d13dbb8e799b39ffe3880601dc64209abdffe13d53bd54efca4L153-R220) [[8]](diffhunk://#diff-9cd0d8c16219d034383795633a189192bb023467a3704a574e963c9bc8a00e53L2-R3) [[9]](diffhunk://#diff-9cd0d8c16219d034383795633a189192bb023467a3704a574e963c9bc8a00e53L58-R64) [[10]](diffhunk://#diff-9cd0d8c16219d034383795633a189192bb023467a3704a574e963c9bc8a00e53L78-R89)

**Other improvements:**

* Added focused v2 unit coverage and updated dev dependencies. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R21) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L114-R116)

These changes improve the reliability and usability of the v2 client, enhance documentation discoverability, and streamline the docs build workflow.